### PR TITLE
`global` command removes "perl-" prefix

### DIFF
--- a/bin/plenv
+++ b/bin/plenv
@@ -184,6 +184,7 @@ sub CMD_local {
 sub write_version_file {
     my ($version, $versionfile) = @_;
     $version =~ s/\s//g;
+    $version =~ s/^perl-//; # remove prefix
 
     if ($version ne 'system' && !is_installed($version)) {
         die "$version is not installed on plenv.";


### PR DESCRIPTION
`install` command removes "perl-" prefix but `global` doesn't.

ex)
This works:

  $ plenv install perl-5.17.8
  #=> Install 5.17.8 to /Users/foo/.plenv/versions/5.17.8

But this doesn't work:

  $ plenv global perl-5.17.8
  #=> perl-5.17.8 is not installed on plenv. at /usr/local/bin/plenv line 189.
