### PR TITLE
Fix for parsing command line argument

### DIFF
--- a/bin/plenv
+++ b/bin/plenv
@@ -274,15 +274,16 @@ sub install {
         'A=s@' => \@A,
         'U=s@' => \@U,
     );
+
+    shift @ARGV if @ARGV >= 1 && $ARGV[0] eq '--';
+
     my @configure_options = @ARGV;
     unless (@configure_options) {
         push @configure_options, '-de';
     }
 
     for (@D, @A, @U) {
-        for (@_) {
-            s/^=//;
-        }
+        s/^=//;
     }
 
     push @configure_options, map { "-D$_" } @D;
@@ -511,7 +512,7 @@ plenv - perl binary manager
     plenv available
 
     # install perl5 binary
-    plenv install 5.16.2 -- -Dusethreads
+    plenv install 5.16.2 -Dusethreads
 
     # execute command on current perl
     plenv exec ack


### PR DESCRIPTION
日本語で失礼しますが、Perl::Buildと同じ問題を修正しました。

あとドキュメントも修正しました。
下記のものなのですが、下記のようにオプションを渡すと '-de'が
指定されないまま, Configureに渡されてしまい、各種設定を
対話的に入力していくことになります。たぶん意図しないものだと
思いますので、修正しました。

```
plenv install 5.16.2 -- -Dusethreads
```
