### PR TITLE
suppress warnings for `brew doctor`

### DIFF
--- a/bin/plenv
+++ b/bin/plenv
@@ -65,7 +65,7 @@ sub CMD_exec {
             grep { File::Spec->canonpath($_) ne File::Spec->canonpath("$PLENV_HOME/shims/") } File::Spec->path()
         );
     } else {
-        my $bindir = "$PLENV_HOME/versions/$version/bin/";
+        my $bindir = "$PLENV_HOME/versions/$version/bin";
         unless (-x File::Spec->catfile($bindir, $bin)) {
             die "[plenv] There is no $bin in $bindir.(determined by @{[ $file || '-' ]})\n";
         }
@@ -82,7 +82,7 @@ sub CMD_which {
 
     my @path = grep { File::Spec->canonpath($_) ne File::Spec->canonpath("$PLENV_HOME/shims/") } File::Spec->path();
     if ($version ne 'system') {
-        unshift @path, "$PLENV_HOME/versions/$version/bin/";
+        unshift @path, "$PLENV_HOME/versions/$version/bin";
     }
 
     if (my $fullpath = which($bin, @path)) {


### PR DESCRIPTION
I got annoying warning at brew doctor, it looks are following:

```
% brew doctor
Warning: Some directories in your path end in a slash.
Directories in your path should not end in a slash. This can break other
doctor checks. The following directories should be edited:
    /Users/shimada.yuji/.plenv/versions/5.16.2/bin/
```

I fixed it.
