### PR TITLE
could not use an installation_name like 'perl-5.16.3'

### DIFF
--- a/bin/plenv
+++ b/bin/plenv
@@ -218,7 +218,7 @@ sub CMD_local {
 sub write_version_file {
     my ($version, $versionfile) = @_;
     $version =~ s/\s//g;
-    $version =~ s/^perl-//; # remove prefix
+    $version =~ s/^perl-// unless is_installed($version) ; # remove prefix
 
     if ($version ne 'system' && !is_installed($version)) {
         die "$version is not installed on plenv.";


### PR DESCRIPTION
I have installed perl 5.16.3 by the command "plenv install 5.16.3 --as perl-5.16.3".
As expected, perl was installed in ~/.plenv/versions/perl-5.16.3.

But "plenv global perl-5.16.3" does not work, because the global option eliminate 'perl-' from the installation name.

I know, this is unexpected usage.
