### PR TITLE
Use --mirror-only for migrate-modules

### DIFF
--- a/bin/plenv
+++ b/bin/plenv
@@ -463,7 +463,7 @@ sub CMD_migrate_modules {
     install_cpanm($dst);
     open my $srcfh, "-|", $srcperl, '-MExtUtils::Installed', '-e', 'print $_, "\n" for ExtUtils::Installed->new->modules'
         or die "Cannot exec: $!";
-    open my $dstfh, "|-", $dstcpanm
+    open my $dstfh, "|-", $dstcpanm, '--mirror-only'
         or die "Cannot exec $dstcpanm: $!";
     while (<$srcfh>) {
         print $dstfh $_;


### PR DESCRIPTION
This would be much faster since it won't hit cpanmetadb for each module when there're hundreds of modules to migrate.
