### PR TITLE
Shims optimization

### DIFF
--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -43,13 +43,13 @@ create_prototype_shim() {
   command -p cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
-[ -n "\$PLENV_DEBUG" ] && set -x
+[[ -n "\$PLENV_DEBUG" ]] && set -x
 
 program="\${0##*/}"
-if [ "\$program" == "perl" ]; then
+if [[ "\$program" = "perl" ]]; then
   for arg; do
     [[ "\$arg" =~ ^(--$|-[0A-Za-z]*[eE].*) ]] && break
-    if [[ "\$arg" =~ / ]] && [ -f "\$arg" ]; then
+    if [[ "\$arg" =~ / && -f "\$arg" ]]; then
       export PLENV_DIR="\${arg%/*}"
       break
     fi

--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -42,21 +42,8 @@ remove_prototype_shim() {
 create_prototype_shim() {
   command -p cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!$(command -v bash)
-set -e
 [[ -n "\$PLENV_DEBUG" ]] && set -x
-
-program="\${0##*/}"
-if [[ "\$program" = "perl" ]]; then
-  for arg; do
-    [[ "\$arg" =~ ^-(-$|[0A-Za-z]*[eE]) ]] && break
-    if [[ "\$arg" =~ / && -f "\$arg" ]]; then
-      export PLENV_DIR="\${arg%/*}"
-      break
-    fi
-  done
-fi
-
-PLENV_ROOT='$PLENV_ROOT' exec '$(command -v plenv)' exec "\$program" "\$@"
+PLENV_ROOT='$PLENV_ROOT' exec '$(command -v plenv)' exec "\${0##*/}" "\$@"
 SH
   command -p chmod +x "$PROTOTYPE_SHIM_PATH"
 }

--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -41,7 +41,7 @@ remove_prototype_shim() {
 # serves as a locking mechanism.
 create_prototype_shim() {
   command -p cat > "$PROTOTYPE_SHIM_PATH" <<SH
-#!/usr/bin/env bash
+#!$(command -v bash)
 set -e
 [[ -n "\$PLENV_DEBUG" ]] && set -x
 

--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -48,7 +48,7 @@ set -e
 program="\${0##*/}"
 if [[ "\$program" = "perl" ]]; then
   for arg; do
-    [[ "\$arg" =~ ^(--$|-[0A-Za-z]*[eE].*) ]] && break
+    [[ "\$arg" =~ ^-(-$|[0A-Za-z]*[eE]) ]] && break
     if [[ "\$arg" =~ / && -f "\$arg" ]]; then
       export PLENV_DIR="\${arg%/*}"
       break

--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -56,8 +56,7 @@ if [[ "\$program" = "perl" ]]; then
   done
 fi
 
-export PLENV_ROOT="$PLENV_ROOT"
-exec "$(command -v plenv)" exec "\$program" "\$@"
+PLENV_ROOT='$PLENV_ROOT' exec '$(command -v plenv)' exec "\$program" "\$@"
 SH
   command -p chmod +x "$PROTOTYPE_SHIM_PATH"
 }

--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -32,7 +32,7 @@ if [[ ! "\$CURRENT_PERL_VERSION" =~ $regexp_system_perl ]] &&
 fi
 
 export PLENV_ROOT="$PLENV_ROOT"
-"$(command -v plenv)" exec "\$program" "\$@"
+'$(command -v plenv)' exec "\$program" "\$@"
 rc=\$?
 for arg in \$@
 do
@@ -42,7 +42,7 @@ do
     ;;
   esac
 done
-"$(command -v plenv)" rehash
+'$(command -v plenv)' rehash
 exit \$rc
 CPANM_SHIM
     else

--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -15,7 +15,7 @@ for _shim in "${cpan_clients[@]}"; do
   if [[ " ${registered_shims[*]} " == *" $_shim "* ]]; then 
     if [[ $_shim == "cpanm" ]]; then
       command -p cat > "$SHIM_PATH/$_shim" <<CPANM_SHIM
-#!/usr/bin/env bash
+#!$(command -v bash)
 set -e
 [ -n "\$PLENV_DEBUG" ] && set -x
 

--- a/plenv.d/rehash/rehash_perl.bash
+++ b/plenv.d/rehash/rehash_perl.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+perl_shim_path="$SHIM_PATH/perl"
+
+command -p cat > "$perl_shim_path" <<SH
+#!$(command -v bash)
+set -e
+[[ -n "\$PLENV_DEBUG" ]] && set -x
+
+for arg; do
+  [[ "\$arg" =~ ^-(-$|[0A-Za-z]*[eE]) ]] && break
+  if [[ "\$arg" =~ / && -f "\$arg" ]]; then
+    export PLENV_DIR="\${arg%/*}"
+    break
+  fi
+done
+
+PLENV_ROOT='$PLENV_ROOT' exec '$(command -v plenv)' exec perl "\$@"
+SH
+command -p chmod +x "$perl_shim_path"


### PR DESCRIPTION
A set of optimization of plenv's shims.
The major optimization is to avoid using `/usr/bin/env` in the shim shebang. (I still dream of getting rid of `/usr/bin/env` in `libexec`).
