### PR TITLE
Fix `plenv()` function in ksh and dash.

### DIFF
--- a/libexec/plenv-init
+++ b/libexec/plenv-init
@@ -88,10 +88,23 @@ if [ -z "$no_rehash" ]; then
 fi
 
 commands=(`plenv-commands --sh`)
+case "$shell" in
+ksh )
+  cat <<EOS
+function plenv {
+  typeset command
+EOS
+  ;;
+* )
+  cat <<EOS
+plenv() {
+  local command
+EOS
+  ;;
+esac
+
 IFS="|"
 cat <<EOS
-plenv() {
-  typeset command
   command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift


### PR DESCRIPTION
dash doesn't support `typeset`.  Use `local` instead.

This commit is inspired by sstephenson/rbenv@5ae2cac088d12fea01054e1f3abbf304b92920b5 .
