### PR TITLE
Improve shell detection.

### DIFF
--- a/libexec/plenv-init
+++ b/libexec/plenv-init
@@ -22,12 +22,14 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(basename "$SHELL")"
+  shell="$(ps c -p $(ps -p $$ -o 'ppid=' 2>/dev/null) -o 'comm=' 2>/dev/null || true)"
+  shell="${shell##-}"
+  shell="$(basename "${shell:-$SHELL}")"
 fi
 
 READLINK=$(type -p greadlink readlink | head -1)
 if [ -z "$READLINK" ]; then
-  echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
+  echo "plenv: cannot find readlink - are you missing GNU coreutils?" >&2
   exit 1
 fi
 


### PR DESCRIPTION
I copied over the improved shell detection from rbenv-init. plenv-init wasn't picking up my zsh shell correctly as it was simply reading from the $SHELL variable.

There are additional changes to rbenv-init mostly around fish shell and completion commands, but I left those out for now.
