### PR TITLE
Allow cpanm to be installed through proxy

### DIFF
--- a/libexec/plenv-install-cpanm
+++ b/libexec/plenv-install-cpanm
@@ -61,5 +61,5 @@ for option in "${OPTIONS[@]}"; do
   esac
 done
 
-curl -L http://cpanmin.us/ | plenv exec perl - ExtUtils::MakeMaker App::cpanminus
+curl -p -L http://cpanmin.us/ | plenv exec perl - ExtUtils::MakeMaker App::cpanminus
 plenv rehash


### PR DESCRIPTION
Curl wasn't working correctly while under a proxy, was getting this error:
curl: (35) error:14077458:SSL routines:SSL23_GET_SERVER_HELLO:reason(1112)
