### PR TITLE
Only rehash cpanm if required

### DIFF
--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -12,7 +12,17 @@ program="\${0##*/}"
 
 export PLENV_ROOT="$PLENV_ROOT"
 "$(command -v plenv)" exec "\$program" "\$@"
+rc=\$?
+for arg in \$@
+do
+  case \$arg in
+    '-h'|'--help'|'-v'|'--version'|'--info'|'-L'|'--local-lib-contained'|'-l'|'--local-lib')
+      exit \$rc
+    ;;
+  esac
+done
 "$(command -v plenv)" rehash
+exit \$rc
 SH
 
 chmod +x "$CPANM_SHIM_PATH"


### PR DESCRIPTION
Created to avoid [lock file](https://github.com/tokuhirom/plenv/blob/master/libexec/plenv-rehash#L21) contention when running multiple instances of cpanm for invocations that don't need to rehash..
