### PR TITLE
plenv-list-modules: don't include the cwd

### DIFF
--- a/libexec/plenv-list-modules
+++ b/libexec/plenv-list-modules
@@ -16,4 +16,4 @@ if [ -z "$PLENV_ROOT" ]; then
   PLENV_ROOT="${HOME}/.plenv"
 fi
 
-plenv exec perl -MExtUtils::Installed -e 'print "$_$/" for ExtUtils::Installed->new->modules'
+plenv exec perl -MExtUtils::Installed -e 'print "$_$/" for ExtUtils::Installed->new(skip_cwd => 1)->modules'


### PR DESCRIPTION
Including the cwd can (easily) cause the command to hang when run from e.g. a home directory, a repo with a large `local/` subdirectory, a root directory &c., rendering it useless.

Remove the "include cwd" default for the common case where you want to find out what modules have been installed to `$PLENV_ROOT/versions/5.xx.x/lib/perl5`.

If anyone really wants to know what Perl modules are installed (potentially) anywhere on their system, they can add an option to enable it :-)