### PR TITLE
Always use system command for avoiding forkbomb(#78)

### DIFF
--- a/libexec/plenv
+++ b/libexec/plenv
@@ -12,11 +12,24 @@ if [ -n "$PLENV_DEBUG" ]; then
   set -x
 fi
 
-READLINK=$(type -p greadlink readlink | head -1)
+head1() {
+  while read line do
+  do
+    echo $line
+    break;
+  done
+}
+
+READLINK=$(type -p greadlink readlink | head1)
 if [ -z "$READLINK" ]; then
   echo "plenv: cannot find readlink - are you missing GNU coreutils?" >&2
   exit 1
 fi
+
+export PLENV_CMD_CAT=$(type -p /bin/cat /usr/bin/cat | head1)
+export PLENV_CMD_LN=$(type -p /bin/ln /usr/bin/ln | head1)
+export PLENV_CMD_CHMOD=$(type -p /bin/chmod /usr/bin/chmod | head1)
+export PLENV_CMD_RM=$(type -p /bin/rm /usr/bin/rm | head1)
 
 resolve_link() {
   $READLINK "$1"

--- a/libexec/plenv-hooks
+++ b/libexec/plenv-hooks
@@ -19,7 +19,7 @@ if [ -z "$PLENV_COMMAND" ]; then
   exit 1
 fi
 
-READLINK=$(type -p greadlink readlink | head -1)
+READLINK=$(type -p greadlink readlink | while read line; do echo $line; break; done)
 if [ -z "$READLINK" ]; then
     echo "plenv: cannot find readlink - are you missing GNU coreutils?" >&2
     exit 1

--- a/libexec/plenv-init
+++ b/libexec/plenv-init
@@ -27,7 +27,7 @@ if [ -z "$shell" ]; then
   shell="$(basename "${shell:-$SHELL}")"
 fi
 
-READLINK=$(type -p greadlink readlink | head -1)
+READLINK=$(type -p greadlink readlink | while read line; do echo $line; break; done)
 if [ -z "$READLINK" ]; then
   echo "plenv: cannot find readlink - are you missing GNU coreutils?" >&2
   exit 1
@@ -119,7 +119,7 @@ fi
 commands=(`plenv-commands --sh`)
 case "$shell" in
 fish )
-  cat <<EOS
+  $PLENV_CMD_CAT <<EOS
 function plenv
   set command \$argv[1]
   set -e argv[1]
@@ -134,7 +134,7 @@ end
 EOS
   ;;
 ksh )
-  cat <<EOS
+  $PLENV_CMD_CAT <<EOS
 function plenv {
   typeset command
 EOS
@@ -149,7 +149,7 @@ esac
 
 if [ "$shell" != "fish" ]; then
 IFS="|"
-cat <<EOS
+$PLENV_CMD_CAT <<EOS
   command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift

--- a/libexec/plenv-local
+++ b/libexec/plenv-local
@@ -36,12 +36,12 @@ fi
 PLENV_VERSION="$1"
 
 if [ "$PLENV_VERSION" = "--unset" ]; then
-  rm -f .perl-version .plenv-version
+  $PLENV_CMD_RM -f .perl-version .plenv-version
 elif [ -n "$PLENV_VERSION" ]; then
   previous_file="$(PLENV_VERSION= plenv-version-origin || true)"
   plenv-version-file-write .perl-version "$PLENV_VERSION"
   if [ "$previous_file" -ef .plenv-version ]; then
-    rm -f .plenv-version
+    $PLENV_CMD_RM -f .plenv-version
     { echo "plenv: removed existing \`.plenv-version' file and migrated"
       echo "       local version specification to \`.perl-version' file"
     } >&2

--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -31,7 +31,7 @@ set +o noclobber
 trap remove_prototype_shim EXIT
 
 remove_prototype_shim() {
-  rm -f "$PROTOTYPE_SHIM_PATH"
+  $PLENV_CMD_RM -f "$PROTOTYPE_SHIM_PATH"
 }
 
 # The prototype shim file is a script that re-execs itself, passing
@@ -40,7 +40,7 @@ remove_prototype_shim() {
 # technique is fast, uses less disk space than unique files, and also
 # serves as a locking mechanism.
 create_prototype_shim() {
-  cat > "$PROTOTYPE_SHIM_PATH" <<SH
+  $PLENV_CMD_CAT > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
 [ -n "\$PLENV_DEBUG" ] && set -x
@@ -59,7 +59,7 @@ fi
 export PLENV_ROOT="$PLENV_ROOT"
 exec "$(command -v plenv)" exec "\$program" "\$@"
 SH
-  chmod +x "$PROTOTYPE_SHIM_PATH"
+  $PLENV_CMD_CHMOD +x "$PROTOTYPE_SHIM_PATH"
 }
 
 # If the contents of the prototype shim file differ from the contents
@@ -68,7 +68,7 @@ SH
 remove_outdated_shims() {
   for shim in *; do
     if ! diff "$PROTOTYPE_SHIM_PATH" "$shim" >/dev/null 2>&1; then
-      for shim in *; do rm -f "$shim"; done
+      for shim in *; do $PLENV_CMD_RM -f "$shim"; done
     fi
     break
   done
@@ -108,7 +108,7 @@ register_shim() {
 install_registered_shims() {
   local shim
   for shim in "${registered_shims[@]}"; do
-    [ -e "$shim" ] || ln -f "$PROTOTYPE_SHIM_PATH" "$shim"
+    [ -e "$shim" ] || $PLENV_CMD_LN -f "$PROTOTYPE_SHIM_PATH" "$shim"
   done
 }
 
@@ -120,7 +120,7 @@ remove_stale_shims() {
   local shim
   for shim in *; do
     if [[ "$registered_shims_index" != *"/$shim/"* ]]; then
-      rm -f "$shim"
+      $PLENV_CMD_RM -f "$shim"
     fi
   done
 }

--- a/libexec/plenv-version-file-read
+++ b/libexec/plenv-version-file-read
@@ -14,7 +14,7 @@ if [ -e "$VERSION_FILE" ]; then
     if [ -z "$version" ] && [ -n "$word" ]; then
       version="$word"
     fi
-  done < <( cat "$VERSION_FILE" && echo )
+  done < <( $PLENV_CMD_CAT "$VERSION_FILE" && echo )
 
   if [ -n "$version" ]; then
     echo "$version"

--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -25,4 +25,4 @@ done
 exit \$rc
 SH
 
-chmod +x "$CPANM_SHIM_PATH"
+$PLENV_CMD_CHMOD +x "$CPANM_SHIM_PATH"


### PR DESCRIPTION
If module(ex PerlPowerTools) installs commands whose names are 'cat', 'head',
'chmod', 'ln', 'rm', then forkbomb is occurred. So we must not use them
and must use system commands instead of them.

This issue is related to #78.