### PR TITLE
Use skip-cwd in plenv-migrate-modules

### DIFF
--- a/libexec/plenv-migrate-modules
+++ b/libexec/plenv-migrate-modules
@@ -54,5 +54,5 @@ esac
 echo "Migrating $FROM to $TO"
 
 PLENV_VERSION=$TO plenv install-cpanm
-PLENV_VERSION=$FROM perl -MExtUtils::Installed -e 'print $_, "\n" for ExtUtils::Installed->new->modules' | PLENV_VERSION=$TO cpanm $no_test --mirror-only
+PLENV_VERSION=$FROM perl -MExtUtils::Installed -e 'print $_, "\n" for ExtUtils::Installed->new(skip_cwd => 1)->modules' | PLENV_VERSION=$TO cpanm $no_test --mirror-only
 PLENV_VERSION=$TO plenv rehash


### PR DESCRIPTION
Otherwise it is possible to "migrate" wrong modules which happen
to be in current dir, e.g. when it is another perl version dir.