### PR TITLE
plenv migrate-modules excludes core Perl

### DIFF
--- a/libexec/plenv-migrate-modules
+++ b/libexec/plenv-migrate-modules
@@ -54,5 +54,5 @@ esac
 echo "Migrating $FROM to $TO"
 
 PLENV_VERSION=$TO plenv install-cpanm
-PLENV_VERSION=$FROM perl -MExtUtils::Installed -e 'print $_, "\n" for ExtUtils::Installed->new(skip_cwd => 1)->modules' | PLENV_VERSION=$TO cpanm $no_test --mirror-only
+PLENV_VERSION=$FROM perl -MExtUtils::Installed -e 'for (ExtUtils::Installed->new(skip_cwd => 1)->modules) {next if /\APerl\z/; print $_, "\n";}' | PLENV_VERSION=$TO cpanm $no_test --mirror-only
 PLENV_VERSION=$TO plenv rehash


### PR DESCRIPTION
plenv migrate-modules doesn't filter a list of modules that are installed so it tries to install core Perl (denoted by 'Perl' by ExtUtils::Installed) which fails (actually it works fine but it gives unnecessary errors). I just added filtering for core Perl to your perl oneliner. You can change this oneliner anyway you want.