### PR TITLE
Fix buggy arg parsing in plenv-init

### DIFF
--- a/libexec/plenv-init
+++ b/libexec/plenv-init
@@ -6,21 +6,20 @@ set -e
 [ -n "$PLENV_DEBUG" ] && set -x
 
 print=""
-no_rehash=1
-for args in "$@"
-do
-  if [ "$args" = "-" ]; then
-    print=1
-    shift
-  fi
+shell=""
 
-  if [ "$args" = "--no-rehash" ]; then
-    no_rehash=1
-    shift
-  fi
+for arg in "$@" ; do
+  case "$arg" in
+  - )
+    print=1
+    ;;
+  --no-rehash )
+    ;;
+  * )
+    [ -z "$shell" ] && shell="$arg"
+  esac
 done
 
-shell="$1"
 if [ -z "$shell" ]; then
   shell="$(ps c -p $(ps -p $$ -o 'ppid=' 2>/dev/null) -o 'comm=' 2>/dev/null || true)"
   shell="${shell##-}"
@@ -111,10 +110,6 @@ fish )
   echo ". '$completion'"
   ;;
 esac
-
-if [ -z "$no_rehash" ]; then
-  echo 'plenv rehash 2>/dev/null'
-fi
 
 commands=(`plenv-commands --sh`)
 case "$shell" in


### PR DESCRIPTION
This is the arg parsing code near the top of `plenv-init`:

````sh
print=""
no_rehash=1
for args in "$@"
do
  if [ "$args" = "-" ]; then
    print=1
    shift
  fi

  if [ "$args" = "--no-rehash" ]; then
    no_rehash=1
    shift
  fi
done

shell="$1"
````

This code is bizarre:

1. There is no way that `no_rehash` is ever going to have a different value than `1`. Is it a removed feature? If so, why does the variable exist? There is also an `if` block further down the file that is dead code because of this, and should go away.

2. This loops across `$@` using a `for` loop, but it uses `shift` (which always removes elements from the front of `$@`) regardless of which loop iteration it’s in.

   Imagine if you invoke it as `plenv init ksh -`. So `$1` is `ksh` and `$2` is `-`. On the first loop iteration, neither `if` block runs. On the second iteration, the first `if` block runs, and it does `shift`, throwing away the *first* element in `$@` (which is `ksh`) rather than the *current* element. Then afterwards, it uses `$1` – which is now `-` because of the `shift` – as the shell name. This makes no sense.

Attached is a patch which has the exact same semantics as the existing code, but without the bugs, and also more readable. Namely: it scans the whole command line for a `-` argument, it ignores any `--no-rehash` flags, and if it finds anything else on the command line, the first of those things is used as the shell name. (Those semantics don’t make much sense to me, but I don’t see anything much to gain by changing them, so \*shrug*.) This is the same thing as the current code tries to do (unsuccessfully).