### PR TITLE
return non-zero if file doesn't exist

### DIFF
--- a/libexec/plenv-version-file-read
+++ b/libexec/plenv-version-file-read
@@ -2,4 +2,5 @@
 # Usage: plenv version-file-read <file>
 # Reads the first non-whitespace word from the specified version file,
 # careful not to load it whole in case there's something crazy in it.
-command -p awk 'NF > 0 { print $1 ; exit 0 } END { exit 1 }' "$1"
+[ -e "$1" ] && \
+  command -p awk 'NF > 0 { print $1 ; exit 0 } END { exit 1 }' "$1"


### PR DESCRIPTION
A slight tweak to syohex's fix for #107 .  plenv-version-file-read should return 0 if it could print a version, or non-zero otherwise.  The prior "if" test returned 0 if the file does not exist.