### PR TITLE
Stop global on success

### DIFF
--- a/libexec/plenv-version-file-read
+++ b/libexec/plenv-version-file-read
@@ -2,4 +2,5 @@
 # Usage: plenv version-file-read <file>
 # Reads the first non-whitespace word from the specified version file,
 # careful not to load it whole in case there's something crazy in it.
-command -p awk 'NF > 0 { print $1 ; exit 0 } END { exit 1 }' "$1"
+[ -e "$1" ] && \
+  command -p awk 'NF > 0 { print $1 ; exit 0 } END { exit 1 }' "$1"

--- a/libexec/plenv-version-file-read
+++ b/libexec/plenv-version-file-read
@@ -2,5 +2,7 @@
 # Usage: plenv version-file-read <file>
 # Reads the first non-whitespace word from the specified version file,
 # careful not to load it whole in case there's something crazy in it.
+# Return 0 if a version is printed, 1 otherwise.
 [ -e "$1" ] && \
-  command -p awk 'NF > 0 { print $1 ; exit 0 } END { exit 1 }' "$1"
+  command -p awk \
+    'BEGIN {rc=1} NF > 0 { print $1 ; exit rc=0 } END { exit rc }' "$1"


### PR DESCRIPTION
Addresses #110 .  The EXIT block always fires; its "exit 1" used to override the "exit 0" from when a version was printed.  Now awk will (as intended) return 0 when a version is printed, and "plenv global" will return just 1 line:

$ plenv global
system
$