### PR TITLE
Bump up version

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,37 @@
+2.2.0 2016-01-20T00:00:00
+
+    - Fix fork bomb issue and cleanup
+      (Aristotle Pagaltzis)
+    - Fix migrate-modules issue
+      (jest, msestak)
+    - Fix list modules issue
+      (chocolateboy)
+    - Support fish shell
+      (syohex)
+    - Fix proxy issue for install-cpanm
+      (Stephen)
+    - Don't execute unnecessary rehash
+      (Dave Miles)
+    - Fix install-cpanm issue
+      (tokuhirom)
+    - Improve shell detection
+      (Finn Smith)
+    - Add fish completion file
+      (Nicolas Leclercq)
+    - Support greadlink environment
+      (tokuhirom)
+    - Fix for ksh and dash
+      (Desmond O. Chang)
+
+2.1.1 2013-09-17T15:22:48
+
+    - Fixed Travis CI issue
+      (tokuhirom, Ingy)
+    - Correct argument handling
+      (Ingy)
+    - Remove needless code
+      (Ingy)
+
 2.1.0 2013-09-04T10:43:51
 
     - Some minor tweaks.

--- a/libexec/plenv---version
+++ b/libexec/plenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$PLENV_DEBUG" ] && set -x
 
-version="2.1.1"
+version="2.2.0"
 
 if cd "$PLENV_ROOT" 2>/dev/null; then
   git_revision="$(git describe --tags HEAD 2>/dev/null || true)"


### PR DESCRIPTION
Homebrew plenv version should be updated for fish shell users. Current homebrew version does not contain fish support code.

See #118 discussion

**Please fix version 2.2.0 version date in Changes and tag new version**