### PR TITLE
Fixed plenv-rehash for older GNU Bash

### DIFF
--- a/libexec/plenv-rehash
+++ b/libexec/plenv-rehash
@@ -48,7 +48,7 @@ set -e
 program="\${0##*/}"
 if [ "\$program" == "perl" ]; then
   for arg; do
-    [[ "\$arg" =~ ^(--$|-[0A-Za-z]*[eE].*) ]] && break
+    [[ "\$arg" =~ "^(--$|-[0A-Za-z]*[eE].*)" ]] && break
     if [[ "\$arg" =~ / ]] && [ -f "\$arg" ]; then
       export PLENV_DIR="\${arg%/*}"
       break


### PR DESCRIPTION
plenv shims are only executable on older GNU bash versions (e.g. 3.1.17) when the regex is enclosed within quotes. 

