### PR TITLE
Don't install EUMM when installing cpanm

### DIFF
--- a/libexec/plenv-install-cpanm
+++ b/libexec/plenv-install-cpanm
@@ -62,5 +62,5 @@ for option in "${OPTIONS[@]}"; do
 done
 
 PLENV_INSTALL_CPANM=${PLENV_INSTALL_CPANM:--p}
-curl ${PLENV_INSTALL_CPANM} -L http://cpanmin.us/ | plenv exec perl - ExtUtils::MakeMaker App::cpanminus
+curl ${PLENV_INSTALL_CPANM} -L http://cpanmin.us/ | plenv exec perl - App::cpanminus
 plenv rehash


### PR DESCRIPTION
Because of JSON:::PP bug, we had to install ExtUtils::MakeMaker before installing cpanminus. https://github.com/tokuhirom/plenv/commit/50e62148806eb4b3d3caffb32b8c5a503e607a70
Now the bug is fixed https://github.com/makamaka/JSON-PP/pull/9, so we don't need the workaround anymore.