### PR TITLE
use system perl by preference when installing

### DIFF
--- a/libexec/plenv
+++ b/libexec/plenv
@@ -90,6 +90,14 @@ case "$command" in
   fi
 
   shift 1
+
+  if [ "$command" = "install" ];then
+    system_perl=$(PLENV_VERSION=system plenv-which perl 2> /dev/null || true)
+    if [ "$system_perl" != "" ]; then
+      exec "$system_perl" "$command_path" "$@"
+    fi
+  fi
+
   exec "$command_path" "$@"
   ;;
 esac


### PR DESCRIPTION
I want to do `plenv install $(cat .perl-version)` (e.g. in setup scripts), but it doen't work now.

    % plenv install $(cat .perl-version)
    plenv: version `5.22.2' is not installed

This pull request resolve this situation by using system perl preferably when installing.