### PR TITLE
plenv-init: fix 'setenv' vs 'set' usage for fish

### DIFF
--- a/libexec/plenv-init
+++ b/libexec/plenv-init
@@ -83,8 +83,8 @@ mkdir -p "${PLENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${PLENV_ROOT}/shims' \$PATH"
-  echo "setenv PLENV_SHELL $shell"
+  echo "set -gx PATH '${PLENV_ROOT}/shims' \$PATH"
+  echo "set -gx PLENV_SHELL $shell"
   ;;
 * )
   echo 'export PATH="'${PLENV_ROOT}'/shims:${PATH}"'


### PR DESCRIPTION
This fixes an incorrect usage of `setenv` in fish, which was revealed by fish itself fixing this usage.

See:

* https://github.com/fish-shell/fish-shell/issues/4103

Here is the code in rbenv:

* https://github.com/rbenv/rbenv/blob/a81da8d864c46c82b8d4ddc8da778f2cdf4274dd/libexec/rbenv-init#L88-L91

And here are the relevant changes made to rbenv with this same fix:

* https://github.com/rbenv/rbenv/commit/be2e606fbdbd8d129563a73a588e33e4fe350665
* https://github.com/rbenv/rbenv/commit/a81da8d864c46c82b8d4ddc8da778f2cdf4274dd

