### PR TITLE
skip plenv-rehash when cpanm -V

### DIFF
--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -16,7 +16,7 @@ rc=\$?
 for arg in \$@
 do
   case \$arg in
-    '-h'|'--help'|'-v'|'--version'|'--info'|'-L'|'--local-lib-contained'|'-l'|'--local-lib')
+    '-h'|'--help'|'-V'|'--version'|'--info'|'-L'|'--local-lib-contained'|'-l'|'--local-lib')
       exit \$rc
     ;;
   esac


### PR DESCRIPTION
Currently plenv skips rehashing when executing cpanm with `-v`.
But `-v` is an abbreviation for `--verbose`, where plenv should not skip rehashing.

Fix this by replacing `-v` with `-V` (which is abbreviation for `--version`).

