### PR TITLE
Tiny fix of regexp for completions' comments

### DIFF
--- a/libexec/plenv-completions
+++ b/libexec/plenv-completions
@@ -11,7 +11,7 @@ if [ -z "$COMMAND" ]; then
 fi
 
 COMMAND_PATH="$(command -v "plenv-$COMMAND" || command -v "plenv-sh-$COMMAND")"
-if grep -i "^\([#%]\|--\|//\) provide plenv completions" "$COMMAND_PATH" >/dev/null; then
+if grep -i "^.*\([#%]\|--\|//\) provide plenv completions" "$COMMAND_PATH" >/dev/null; then
   shift
   exec "$COMMAND_PATH" --complete "$@"
 fi


### PR DESCRIPTION
This fix allows to have comments with `provide plenv completions` not
only as standalone strings but also for embedded inline comments. Also,
the commit fixes completions for `plenv commands` command and other
possibly broken before commands.

Signed-off-by: Georgiy Odisharia <math.kraut.cat@gmail.com>