### PR TITLE
Fix #146

### DIFF
--- a/plenv.d/rehash/rehash_cpanm.bash
+++ b/plenv.d/rehash/rehash_cpanm.bash
@@ -21,7 +21,7 @@ set -e
 
 program="\${0##*/}"
 
-CURRENT_PERL_VERSION=\$(plenv version-name)
+CURRENT_PERL_VERSION=\$("$(command -v plenv)" version-name)
 
 # Respect this env vars for system-wide perl and when they're set by
 # \`plenv use\`  command (see plenv-contrib for local::lib integration).
@@ -53,7 +53,7 @@ set -e
 
 program="\${0##*/}"
 
-CURRENT_PERL_VERSION=\$(plenv version-name)
+CURRENT_PERL_VERSION=\$("$(command -v plenv)"  version-name)
 
 # Respect this env vars for system-wide perl and when they're set by
 # \`plenv use\`  command (see plenv-contrib for local::lib integration).


### PR DESCRIPTION
Recently I created hooks for CPAN tools shims in which I made mistake
when called plenv with assumption it's in $PATH envvar. Now it's called
by its absolute path.

Signed-off-by: Georgiy Odisharia <math.kraut.cat@gmail.com>