### PR TITLE
list-modules: skip "Perl" module

### DIFF
--- a/libexec/plenv-list-modules
+++ b/libexec/plenv-list-modules
@@ -16,4 +16,4 @@ if [ -z "$PLENV_ROOT" ]; then
   PLENV_ROOT="${HOME}/.plenv"
 fi
 
-plenv exec perl -MExtUtils::Installed -e 'print "$_$/" for ExtUtils::Installed->new(skip_cwd => 1)->modules'
+plenv exec perl -MExtUtils::Installed -e 'print "$_$/" for grep $_ ne "Perl", ExtUtils::Installed->new(skip_cwd => 1)->modules'


### PR DESCRIPTION
`ExtUtils::Installed->new->modules` returns the special module "Perl" for the core.
See https://metacpan.org/pod/ExtUtils::Installed#modules()

As a result, `plenv list-modules` also returns "Perl" module.
I think we should remove it because it is not a real module.