### PR TITLE
copy-from-rbenv now checks that rbenv dirs exist and aren't empty

### DIFF
--- a/author/copy-from-rbenv.sh
+++ b/author/copy-from-rbenv.sh
@@ -1,45 +1,50 @@
 #!/bin/bash
-mkdir -p libexec completions
-rm -f completions/*
-rm -f \
-       libexec/plenv \
-       libexec/plenv---version \
-       libexec/plenv-commands \
-       libexec/plenv-completions \
-       libexec/plenv-exec \
-       libexec/plenv-global \
-       libexec/plenv-help \
-       libexec/plenv-hooks \
-       libexec/plenv-init \
-       libexec/plenv-local \
-       libexec/plenv-prefix \
-       libexec/plenv-rehash \
-       libexec/plenv-root \
-       libexec/plenv-sh-rehash \
-       libexec/plenv-sh-shell \
-       libexec/plenv-shims \
-       libexec/plenv-version \
-       libexec/plenv-version-file \
-       libexec/plenv-version-file-read \
-       libexec/plenv-version-file-write \
-       libexec/plenv-version-name \
-       libexec/plenv-version-origin \
-       libexec/plenv-versions \
-       libexec/plenv-whence \
-       libexec/plenv-which
-cp ~/.rbenv/libexec/* libexec/
-cp ~/.rbenv/completions/* completions/
+if [[ "$(ls -A ~/.rbenv)" && "$(ls -A ~/.rbenv/libexec)" && "$(ls -A ~/.rbenv/completions)" ]];
+then
+       mkdir -p libexec completions
+       rm -f completions/*
+       rm -f \
+              libexec/plenv \
+              libexec/plenv---version \
+              libexec/plenv-commands \
+              libexec/plenv-completions \
+              libexec/plenv-exec \
+              libexec/plenv-global \
+              libexec/plenv-help \
+              libexec/plenv-hooks \
+              libexec/plenv-init \
+              libexec/plenv-local \
+              libexec/plenv-prefix \
+              libexec/plenv-rehash \
+              libexec/plenv-root \
+              libexec/plenv-sh-rehash \
+              libexec/plenv-sh-shell \
+              libexec/plenv-shims \
+              libexec/plenv-version \
+              libexec/plenv-version-file \
+              libexec/plenv-version-file-read \
+              libexec/plenv-version-file-write \
+              libexec/plenv-version-name \
+              libexec/plenv-version-origin \
+              libexec/plenv-versions \
+              libexec/plenv-whence \
+              libexec/plenv-which
+       cp ~/.rbenv/libexec/* libexec/
+       cp ~/.rbenv/completions/* completions/
 
 
-rename 's/rbenv/plenv/' libexec/* completions/*
-/usr/bin/perl -i -pe 's!github.com/sstephenson/rbenv!github.com/tokuhirom/plenv!g; s/RUBY/PERL/g; s/rbenv/plenv/g;s/RBENV/PLENV/g;s/Ruby/Perl/g;s/ruby/perl/g; s/1.9.3-p327/5.18.0/g; s/bundle install/carton install/g' libexec/* completions/*
-chmod +x libexec/*
-grep sstephenson libexec/* plugins/*/* completions/*
+       rename 's/rbenv/plenv/' libexec/* completions/*
+       /usr/bin/perl -i -pe 's!github.com/sstephenson/rbenv!github.com/tokuhirom/plenv!g; s/RUBY/PERL/g; s/rbenv/plenv/g;s/RBENV/PLENV/g;s/Ruby/Perl/g;s/ruby/perl/g; s/1.9.3-p327/5.18.0/g; s/bundle install/carton install/g' libexec/* completions/*
+       chmod +x libexec/*
+       grep sstephenson libexec/* plugins/*/* completions/*
 
-# enable --no-rehash by default
-perl -i -pe 's/no_rehash=""/no_rehash=1/' libexec/plenv-init
+       # enable --no-rehash by default
+       perl -i -pe 's/no_rehash=""/no_rehash=1/' libexec/plenv-init
 
-git_revision="$(git describe --tags HEAD | sed -e 's/-.*//' 2>/dev/null || true)"
-export GIT_REVISION=$git_revision
-perl -i -pe 's/version="[0-9.]+"/version="$ENV{GIT_REVISION}"/' libexec/plenv---version
-perl -i -pe 's!print_summaries commands local global shell install uninstall rehash version versions which whence!print_summaries commands local global shell install uninstall rehash version versions which whence list-modules migrate-modules install-cpanm!; s!%-9s!%-17s!' libexec/plenv-help
+       git_revision="$(git describe --tags HEAD | sed -e 's/-.*//' 2>/dev/null || true)"
+       export GIT_REVISION=$git_revision
+       perl -i -pe 's/version="[0-9.]+"/version="$ENV{GIT_REVISION}"/' libexec/plenv---version
+       perl -i -pe 's!print_summaries commands local global shell install uninstall rehash version versions which whence!print_summaries commands local global shell install uninstall rehash version versions which whence list-modules migrate-modules install-cpanm!; s!%-9s!%-17s!' libexec/plenv-help
+else
+    echo "rbenv not detected for this user, no changes were made."
+fi


### PR DESCRIPTION
While looking at open issues, I happened to run 'make' on my (working, up to date) plenv installation. The script author/copy-from-rbenv.sh trashed my plenv install. This patch checks that ~/.rbenv, ~/.rbenv/completions, and ~/.rbenv/libexec exist and are not empty before whacking the corresponding plenv directories.

Git status revealed the damage:
	deleted:    completions/plenv.bash
	deleted:    completions/plenv.fish
	deleted:    completions/plenv.zsh
	deleted:    libexec/plenv
	deleted:    libexec/plenv---version
	deleted:    libexec/plenv-commands
	deleted:    libexec/plenv-completions
	deleted:    libexec/plenv-exec
	deleted:    libexec/plenv-global
	deleted:    libexec/plenv-help
	deleted:    libexec/plenv-hooks
	deleted:    libexec/plenv-init
	deleted:    libexec/plenv-local
	deleted:    libexec/plenv-prefix
	deleted:    libexec/plenv-rehash
	deleted:    libexec/plenv-root
	deleted:    libexec/plenv-sh-rehash
	deleted:    libexec/plenv-sh-shell
	deleted:    libexec/plenv-shims
	deleted:    libexec/plenv-version
	deleted:    libexec/plenv-version-file
	deleted:    libexec/plenv-version-file-read
	deleted:    libexec/plenv-version-file-write
	deleted:    libexec/plenv-version-name
	deleted:    libexec/plenv-version-origin
	deleted:    libexec/plenv-versions
	deleted:    libexec/plenv-whence
	deleted:    libexec/plenv-which