### PR TITLE
Fix issue#181 plenv: no such command `shell'

### DIFF
--- a/libexec/plenv-shell
+++ b/libexec/plenv-shell
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Summary: Explain user error of calling this command instead of shell function
+# Usage: plenv shell [...]
+
+set -e
+[ -n "$PLENV_DEBUG" ] && set -x
+
+echo "Your shell is not yet configured to use plenv." >&2
+echo "See: https://github.com/tokuhirom/plenv#installation" >&2
+exit 1


### PR DESCRIPTION
Technically issue#181 arises from a mis-use like: user just adds plenv/bin to thier $PATH and does no shell configuration.

But we know what the user **wanted** to do, so provide a helpful error message telling them to finish the installation instructions.